### PR TITLE
Fix time/time zone related failing tests

### DIFF
--- a/app/models/concerns/event_decorators.rb
+++ b/app/models/concerns/event_decorators.rb
@@ -11,11 +11,19 @@ module EventDecorators
     start_date.strftime('%Y')
   end
 
+  def start_date_in_time_zone
+    start_date.in_time_zone(time_zone)
+  end
+
+  def end_date_in_time_zone
+    end_date.in_time_zone(time_zone)
+  end
+
   def days
-    day = start_date.to_time.in_time_zone(time_zone).beginning_of_day
+    day = start_date_in_time_zone.beginning_of_day
     days = [day]
     # Compare date strings so TZ issues don't interfere
-    end_of_ws = end_date.to_time.in_time_zone(time_zone).end_of_day
+    end_of_ws = end_date_in_time_zone.end_of_day
     datestring = end_of_ws.strftime('%Y%m%d').to_s
     until day.strftime('%Y%m%d').to_s == datestring
       day += 1.day

--- a/app/models/concerns/schedule_helpers.rb
+++ b/app/models/concerns/schedule_helpers.rb
@@ -8,48 +8,42 @@ module ScheduleHelpers
   extend ActiveSupport::Concern
 
   def notify_staff?
-    event.current?
+    event_memo.current?
   end
 
-    # Convert to event's time zone
-  def self.start_time
-    super.in_time_zone(self.event.time_zone) if super && self.event.time_zone
+  def start_time_in_time_zone
+    event_memo&.time_zone ? start_time.in_time_zone(event_memo.time_zone) : start_time
   end
 
-  def self.end_time
-    super.in_time_zone(self.event.time_zone) if super && self.event.time_zone
+  def end_time_in_time_zone
+    event_memo&.time_zone ? end_time.in_time_zone(event_memo.time_zone) : end_time
   end
 
   def times_use_event_timezone
-    unless start_time.nil? || end_time.nil? || event.nil?
-      start_time.time_zone.name == event.time_zone &&
-          end_time.time_zone.name == event.time_zone
+    unless start_time.nil? || end_time.nil? || event_memo.nil?
+      start_time.time_zone.name == event_memo.time_zone &&
+          end_time.time_zone.name == event_memo.time_zone
     end
   end
 
   def times_within_event
-    schedule_start = start_time.to_time.in_time_zone(event.time_zone).to_i
-    schedule_end = end_time.to_time.in_time_zone(event.time_zone).to_i
-    event_start = event.start_date.to_time.in_time_zone(event.time_zone).to_i
-    event_end = event.end_date.to_time.in_time_zone(event.time_zone).change({ hour: 23 }).to_i
-
+    schedule_start = start_time_in_time_zone.to_i
+    schedule_end = end_time_in_time_zone.to_i
+    event_start = event_memo.start_date_in_time_zone.to_i
+    event_end = event_memo.end_date_in_time_zone.change({ hour: 23 }).to_i
     if schedule_start < event_start || schedule_start > event_end
-      errors.add(:start_time, "- must be within the event dates")
+      errors.add(:start_time, '- must be within the event dates')
     end
 
-    if schedule_end < event_start || schedule_end > event_end
-      errors.add(:end_time, "- must be within the event dates")
-    end
+    errors.add(:end_time, '- must be within the event dates') if schedule_end < event_start || schedule_end > event_end
   end
 
   def missing_data
-    event.blank? || start_time.blank? || end_time.blank?
+    event_memo.blank? || start_time.blank? || end_time.blank?
   end
 
   def ends_after_begins
-    if end_time <= start_time
-      errors.add(:end_time, "- must be greater than start time")
-    end
+    errors.add(:end_time, '- must be greater than start time') if end_time <= start_time
   end
 
   # Schedule items can overlap, but not Lectures
@@ -57,7 +51,7 @@ module ScheduleHelpers
     if self.is_a?(Schedule)
       add_overlaps_warning(other)
     else
-      field = 'time' if field.to_s.match?("_time")
+      field = 'time' if field.to_s.match?('_time')
       add_error(field, other)
     end
   end
@@ -65,13 +59,16 @@ module ScheduleHelpers
   def times_overlap
     self.class.where("((start_time, end_time) OVERLAPS
                       (timestamp :start, timestamp :end)) AND id != :myself",
-                      :start => self.start_time, :end => self.end_time,
-                      :myself => self.id.nil? ? 0 : self.id
-    ).order(:start_time).each { |other| errors_or_warnings(:start_time, other) }
+                     start: start_time, end: end_time,
+                     myself: id.nil? ? 0 : id).order(:start_time).each { |other| errors_or_warnings(:start_time, other) }
   end
 
   def clean_data
     # remove leading & trailing whitespace
     attributes.each_value { |v| v.strip! if v.respond_to? :strip! }
+  end
+
+  def event_memo
+    @even_memo ||= event
   end
 end

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -105,13 +105,10 @@ class Invitation < ApplicationRecord
 
   def update_times
     self.invited_on = DateTime.current
-    if self.membership.event.online? || self.membership.virtual?
-      self.expires = event.end_date.to_time
-                          .in_time_zone(event.time_zone)
-                          .end_of_day
+    if membership.event.online? || membership.virtual?
+      self.expires = event.end_date_in_time_zone.end_of_day
     else
-      start_time = event.start_date.to_time
-                        .in_time_zone(event.time_zone).beginning_of_day
+      start_time = event.start_date_in_time_zone.beginning_of_day
       self.expires = start_time - EXPIRES_BEFORE
     end
   end

--- a/app/services/invitation_checker.rb
+++ b/app/services/invitation_checker.rb
@@ -105,7 +105,7 @@ class InvitationChecker
 
     # some invitations were sent before the invitee was Virtual
     if invitation.membership.role.match?('Virtual')
-      invitation.expires = invitation.event.end_date.to_time.end_of_day
+      invitation.expires = invitation.event.end_date.end_of_day
       invitation.save
     end
 

--- a/app/services/rsvp_deadline.rb
+++ b/app/services/rsvp_deadline.rb
@@ -24,9 +24,9 @@
 class RsvpDeadline
   def initialize(event, sent_on = DateTime.current, membership = false)
     @event = event
-    @start_date = event.start_date.to_time.in_time_zone(event.time_zone)
-    @end_date = event.end_date.to_time.in_time_zone(event.time_zone)
-    @sent_on = sent_on.to_time.in_time_zone(event.time_zone)
+    @start_date = event.start_date_in_time_zone
+    @end_date = event.end_date_in_time_zone
+    @sent_on = sent_on.in_time_zone(event.time_zone)
     @membership = membership || Membership.new(role: 'Virtual Participant')
   end
 

--- a/app/services/schedule_item.rb
+++ b/app/services/schedule_item.rb
@@ -63,8 +63,8 @@ class ScheduleItem
     unless new_day.nil?
       the_date = { year: new_day.to_date.year, month: new_day.to_date.month,
                    day: new_day.to_date.mday }
-      new_schedule.start_time = new_schedule.start_time.to_time.change(the_date)
-      new_schedule.end_time = new_schedule.end_time.to_time.change(the_date)
+      new_schedule.start_time = new_schedule.start_time.change(the_date)
+      new_schedule.end_time = new_schedule.end_time.change(the_date)
     end
     [new_schedule, the_date]
   end
@@ -222,8 +222,7 @@ class ScheduleItem
 
   def set_default_start_time
     phour, pminute = most_popular_start_time.split(':')
-    start_time = @schedule.start_time.to_time.in_time_zone(@event.time_zone)
-                          .change({ hour: phour, min: pminute })
+    start_time = @schedule.start_time_in_time_zone.change({ hour: phour, min: pminute })
 
     unless @todays_schedule.empty?
       todays_lectures = @todays_schedule.select {|s| s unless s.lecture_id.nil? }

--- a/spec/controllers/lectures_controller_spec.rb
+++ b/spec/controllers/lectures_controller_spec.rb
@@ -94,8 +94,7 @@ RSpec.describe LecturesController, type: :controller do
       @event = create(:event, start_date: start_date, end_date: end_date)
       start_time = Time.now + 2.hours
       end_time = start_time + 40.minutes
-      @lecture = create(:lecture, event: @event, start_time: start_time,
-                               end_time: end_time)
+      @lecture = create(:lecture, event: @event, start_time: start_time, end_time: end_time)
       @room = @lecture.room
     end
 

--- a/spec/controllers/memberships_controller_spec.rb
+++ b/spec/controllers/memberships_controller_spec.rb
@@ -1009,10 +1009,8 @@ RSpec.describe MembershipsController, type: :controller do
             @event.max_virtual = @event.num_invited_virtual
             @event.save
 
-            member = create(:membership, attendance: 'Not Yet Invited',
-                                               role: 'Observer')
-            post :invite, params: { event_id: @event.id, invite_members_form:
-                      { "#{member.id}": "1" } }
+            member = create(:membership, attendance: 'Not Yet Invited', role: 'Observer')
+            post :invite, params: { event_id: @event.id, invite_members_form: { "#{member.id}": "1" } }
 
             expect(flash[:success]).to be_present
             updated_member = Membership.find(member.id)

--- a/spec/controllers/schedule_controller_spec.rb
+++ b/spec/controllers/schedule_controller_spec.rb
@@ -12,9 +12,7 @@ RSpec.describe ScheduleController, type: :controller do
     authenticate_for_controllers
     build_schedule_template(@event.event_type)
 
-    start_time = (@event.start_date + 1.days)
-                 .to_time.in_time_zone(@event.time_zone)
-                 .change(hour: 9, min: 0)
+    start_time = (@event.start_date + 1.days).in_time_zone(@event.time_zone).change(hour: 9, min: 0)
     end_time = start_time.change(hour: 9, min: 30)
     @valid_attributes = attributes_for(:schedule, event_id: @event.id,
                                                   start_time: start_time,
@@ -39,9 +37,7 @@ RSpec.describe ScheduleController, type: :controller do
       before do
         sign_out @user
         (9..16).each do |hour|
-          start_time = (@event.start_date + 1.days)
-                       .to_time.in_time_zone(@event.time_zone)
-                       .change(hour: hour, min: 0)
+          start_time = (@event.start_date + 1.days).in_time_zone(@event.time_zone).change(hour: hour, min: 0)
           end_time = start_time.change(hour: hour, min: 30)
           name = "Schedule Item at #{hour}"
           create(:schedule, event: @event, start_time: start_time,
@@ -142,11 +138,9 @@ RSpec.describe ScheduleController, type: :controller do
       @membership.role = 'Organizer'
       @membership.save
 
-      start_time = (@event.start_date + 1.days).to_time
-                    .in_time_zone(@event.time_zone).change(hour: 9, min: 0)
+      start_time = (@event.start_date + 1.days).in_time_zone(@event.time_zone).change(hour: 9, min: 0)
       end_time = start_time.change(hour: 9, min: 30)
-      schedule = create(:schedule, event: @event,
-                                   start_time: start_time, end_time: end_time)
+      schedule = create(:schedule, event: @event, start_time: start_time, end_time: end_time)
 
       get :edit, params: { event_id: @event.id, id: schedule.to_param }
       expect(assigns(:schedule)).to eq(schedule)
@@ -564,8 +558,8 @@ RSpec.describe ScheduleController, type: :controller do
       speaker = create(:membership, event: @event).person
       talk = create(:lecture, event: @event, person: speaker,
                       title: 'Test talk', room: 'Online',
-                 start_time: DateTime.now.change({ hour:12, min:0}),
-                   end_time:  DateTime.now.change({ hour:12, min:30}))
+                 start_time: DateTime.current.change({ hour:12, min:0}),
+                   end_time:  DateTime.current.change({ hour:12, min:30}))
 
       @schedule_item = create(:schedule, event: @event, lecture: talk,
                               name: talk.title, location: talk.room,
@@ -612,8 +606,8 @@ RSpec.describe ScheduleController, type: :controller do
 
       context 'on a day other than today' do
         it 'denies access' do
-          @schedule_item.start_time = DateTime.now.tomorrow.change({ hour:12, min:0})
-          @schedule_item.end_time = DateTime.now.tomorrow.change({ hour:12, min:30})
+          @schedule_item.start_time = DateTime.current.tomorrow.change({ hour: 12, min: 0})
+          @schedule_item.end_time = DateTime.current.tomorrow.change({ hour: 12, min: 30})
           @schedule_item.save
 
           post :recording, params: @start_params

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -107,11 +107,10 @@ FactoryBot.define do
       after(:create) do |event|
         9.upto(12) do |t|
           create(:schedule,
-            event: event,
-            name: "Item at #{t}",
-            start_time: (event.start_date + 2.days).to_time.change({ hour: t }),
-            end_time: (event.start_date + 2.days).to_time.change({ hour: t+1 })
-          )
+                 event: event,
+                 name: "Item at #{t}",
+                 start_time: (event.start_date + 2.days).in_time_zone(event.time_zone).change({ hour: t }),
+                 end_time: (event.start_date + 2.days).in_time_zone(event.time_zone).change({ hour: t + 1 }))
         end
       end
     end

--- a/spec/factories/lectures.rb
+++ b/spec/factories/lectures.rb
@@ -8,8 +8,8 @@ FactoryBot.define do
     person { association :person }
 
     f.title
-    f.start_time { (event.start_date + 1.days).to_time.in_time_zone(event.time_zone).change({ hour:9, min:0}) }
-    f.end_time { (event.start_date + 1.days).to_time.in_time_zone(event.time_zone).change({ hour:10, min:0}) }
+    f.start_time { (event.start_date + 1.days).in_time_zone(event.time_zone).change({ hour: 9, min: 0 }) }
+    f.end_time { (event.start_date + 1.days).in_time_zone(event.time_zone).change({ hour: 10, min: 0 }) }
     f.room { 'TCPL 201' }
     f.do_not_publish { false }
     f.abstract { Faker::Lorem.sentence(word_count: 2) }

--- a/spec/factories/schedules.rb
+++ b/spec/factories/schedules.rb
@@ -8,8 +8,8 @@ FactoryBot.define do
     f.location { 'TCPL 201' }
     f.description { Faker::Lorem.sentence(word_count: 4) }
     f.updated_by { 'FactoryBot' }
-    f.start_time { (event.start_date + 1.days).to_time.in_time_zone(event.time_zone).change({ hour:9, min:0}) }
-    f.end_time { (event.start_date + 1.days).to_time.in_time_zone(event.time_zone).change({ hour:10, min:0}) }
+    f.start_time { (event.start_date + 1.days).in_time_zone(event.time_zone).change({ hour: 9, min: 0 }) }
+    f.end_time { (event.start_date + 1.days).in_time_zone(event.time_zone).change({ hour: 10, min: 0 }) }
   end
 end
 

--- a/spec/mailers/invitation_mailer_spec.rb
+++ b/spec/mailers/invitation_mailer_spec.rb
@@ -178,7 +178,7 @@ RSpec.describe InvitationMailer, type: :mailer do
         delivery = ActionMailer::Base.deliveries.first
         body = delivery.body.empty? ? delivery.text_part : delivery.body
 
-        rsvp_date = @event.end_date.to_time.strftime('%B %-d, %Y')
+        rsvp_date = @event.end_date.strftime('%B %-d, %Y')
         expect(body).to have_text("before #{rsvp_date}")
       end
     end
@@ -195,7 +195,7 @@ RSpec.describe InvitationMailer, type: :mailer do
         delivery = ActionMailer::Base.deliveries.first
         body = delivery.body.empty? ? delivery.text_part : delivery.body
 
-        rsvp_date = @event.end_date.to_time.strftime('%B %-d, %Y')
+        rsvp_date = @event.end_date.strftime('%B %-d, %Y')
         expect(body).to have_text("before #{rsvp_date}")
       end
 

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Model validations: Event ", type: :model do
 
   it 'factory produces legitimate start and end dates' do
     event = build(:event)
-    expect(event.start_date.to_time.to_i).to be < event.end_date.to_time.to_i
+    expect(event.start_date).to be < event.end_date
   end
 
   it 'is invalid without a name' do

--- a/spec/models/invitation_spec.rb
+++ b/spec/models/invitation_spec.rb
@@ -45,8 +45,7 @@ RSpec.describe 'Model validations: Invitation', type: :model do
     i = create(:invitation, membership: membership)
 
     duration = Invitation.duration_setting
-    start_date = event.start_date.to_time
-                      .in_time_zone(event.time_zone).beginning_of_day
+    start_date = event.start_date_in_time_zone.beginning_of_day
 
     expect(i.expires).to eq(start_date - duration)
   end
@@ -56,7 +55,7 @@ RSpec.describe 'Model validations: Invitation', type: :model do
     membership = build(:membership, event: event)
     i = create(:invitation, membership: membership)
 
-    end_time = event.end_date.to_time.end_of_day.in_time_zone(event.time_zone)
+    end_time = event.end_date.end_of_day.in_time_zone(event.time_zone)
     expect(i.expires).to eq(end_time)
   end
 
@@ -66,7 +65,7 @@ RSpec.describe 'Model validations: Invitation', type: :model do
     membership = build(:membership, event: event, role: 'Virtual Participant')
     i = create(:invitation, membership: membership)
 
-    end_time = event.end_date.to_time.end_of_day.in_time_zone(event.time_zone)
+    end_time = event.end_date.end_of_day.in_time_zone(event.time_zone)
     expect(i.expires).to eq(end_time)
   end
 
@@ -113,9 +112,8 @@ RSpec.describe 'Model validations: Invitation', type: :model do
       reminders = invitation.membership.invite_reminders
       expect(reminders).not_to be_empty
       expect(reminders.values.last).to eq('FactoryBot')
-
       reminded_on = reminders.keys.first.strftime("%Y-%m-%d %H:%M")
-      expect(reminded_on).to eq(DateTime.now.strftime("%Y-%m-%d %H:%M"))
+      expect(reminded_on).to eq(DateTime.current.strftime("%Y-%m-%d %H:%M"))
     end
 
     it 'sets the mailer template' do

--- a/spec/requests/api/lectures_api_controller_spec.rb
+++ b/spec/requests/api/lectures_api_controller_spec.rb
@@ -105,9 +105,7 @@ describe Api::V1::LecturesController, type: :request do
       before do
         allow_any_instance_of(Api::V1::LecturesController).to receive(:authenticated?).and_return(true)
         allow_any_instance_of(Api::V1::BaseController).to receive(:authenticate_user_from_token!).and_return(true)
-        start_time = (@event.start_date + 1.days).to_time
-                                               .in_time_zone(@event.time_zone)
-                                               .change({ hour:11, min:0})
+        start_time = (@event.start_date + 1.days).in_time_zone(@event.time_zone).change({ hour: 11, min: 0 })
         end_time = start_time + 1.hour
         3.times do
           lecture = create(:lecture, event: @event, start_time: start_time, end_time: end_time)
@@ -124,7 +122,7 @@ describe Api::V1::LecturesController, type: :request do
           json = JSON.parse(response.body)
 
           Lecture.all.each do |lecture|
-            record = json.detect {|item| item['lecture']['id'].to_i == lecture.id }
+            record = json.detect { |item| item['lecture']['id'].to_i == lecture.id }
             expect(record['lecture']['title']).to eq(lecture.title)
             expect(record['lecture']['event_format']).to eq(lecture.event.event_format)
             expect(record['lecture']['event_location']).to eq(lecture.event.location)
@@ -166,7 +164,8 @@ describe Api::V1::LecturesController, type: :request do
           json = JSON.parse(response.body)
 
           Lecture.all.each do |lecture|
-            record = json.detect {|item| item['lecture']['id'].to_i == lecture.id }
+            record = json.detect { |item| item['lecture']['id'].to_i == lecture.id }
+
             expect(record['lecture']['title']).to eq(lecture.title)
             expect(record['lecture']['event_format']).to eq(lecture.event.event_format)
             expect(record['lecture']['event_location']).to eq(lecture.event.location)

--- a/spec/services/default_schedule_spec.rb
+++ b/spec/services/default_schedule_spec.rb
@@ -41,8 +41,7 @@ describe 'DefaultSchedule' do
                        event_type: @event.event_type,
                        start_date: '2015-01-04',
                        end_date: '2015-01-09',
-                       template: true
-      )
+                       template: true)
       @tevent.schedules.each do |s|
         s.staff_item = true
         s.save
@@ -60,12 +59,11 @@ describe 'DefaultSchedule' do
 
       context 'If the event has at least one schedule item' do
         before do
-          start_time = (@event.start_date + 2.days).to_time
-                        .in_time_zone(@event.time_zone).change({ hour: 9 })
+          start_time = (@event.start_date + 2.days).in_time_zone(@event.time_zone).change({ hour: 9 })
           item = build(:schedule, name: 'This one item', event_id: @event.id,
-            start_time: start_time,
-            end_time: start_time.change({ hour: 10 })
-          )
+                                  start_time: start_time,
+                                  end_time: start_time.change({ hour: 10 }))
+
           @event.schedules.create(item.attributes)
         end
 
@@ -111,13 +109,11 @@ describe 'DefaultSchedule' do
         before do
           @event.schedules.delete_all
 
-          start_time = (@event.start_date + 2.days).to_time
-                        .in_time_zone(@event.time_zone).change({ hour: 9 })
+          start_time = (@event.start_date + 2.days).in_time_zone(@event.time_zone).change({ hour: 9 })
           item = build(:schedule, name: 'Default item', event_id: @event.id,
-            start_time: start_time,
-            end_time: start_time.change(hour: 10),
-            updated_by: 'Default Schedule'
-          )
+                                  start_time: start_time,
+                                  end_time: start_time.change(hour: 10),
+                                  updated_by: 'Default Schedule')
           @event.schedules.create(item.attributes)
         end
 

--- a/spec/services/event_maillist_spec.rb
+++ b/spec/services/event_maillist_spec.rb
@@ -130,9 +130,7 @@ describe 'EventMaillist' do
       hour = 8
       event2.attendance('Confirmed').sample(speaker_count).each do |speaker|
         hour += 1
-        start_time = (event2.start_date + 1.days).to_time
-                            .in_time_zone(event2.time_zone)
-                            .change({ hour: hour, min:0})
+        start_time = (event2.start_date + 1.days).in_time_zone(event2.time_zone).change({ hour: hour, min:0})
         end_time = start_time + 45.minutes
         create(:lecture, person: speaker.person, event: event2,
                          start_time: start_time, end_time: end_time)

--- a/spec/services/get_lectures_spec.rb
+++ b/spec/services/get_lectures_spec.rb
@@ -53,7 +53,7 @@ describe 'GetLectures' do
 
     before do
       @room = 'Empty'
-      @event = create(:event, start_date: Date.today, end_date: Date.today + 5.days)
+      @event = create(:event, start_date: Date.today, end_date: Time.zone.today + 5.days)
       travel_to @event.start_date_in_time_zone.change({ hour: 9 })
     end
 

--- a/spec/services/get_lectures_spec.rb
+++ b/spec/services/get_lectures_spec.rb
@@ -6,7 +6,7 @@
 
 require 'rails_helper'
 
-describe "GetLectures" do
+describe 'GetLectures' do
   context '.initialize' do
     before do
       @event = add_lectures_on(Date.current)
@@ -49,22 +49,27 @@ describe "GetLectures" do
   end
 
   context '.current' do
+    include ActiveSupport::Testing::TimeHelpers
+
     before do
       @room = 'Empty'
-      @event = create(:event, start_date: Date.today,
-                                end_date: Date.today + 5.days)
+      @event = create(:event, start_date: Date.today, end_date: Date.today + 5.days)
+      travel_to @event.start_date_in_time_zone.change({ hour: 9 })
+    end
+
+    after do
+      travel_back
     end
 
     it 'returns the lecture closest to the current time' do
       start_time = Time.current - 1.hour
       end_time = start_time + 30.minutes
-      create(:lecture, event: @event, start_time: start_time,
-                    end_time: end_time, room: @room)
-      create(:lecture, event: @event, start_time: start_time + 2.hours,
-                    end_time: end_time + 2.hours, room: @room)
-      lecture = create(:lecture, event: @event, room: @room,
-                           start_time: Time.current - 10.minutes,
-                           end_time: Time.current + 20.minutes)
+      create(:lecture, event: @event, start_time: start_time, end_time: end_time, room: @room)
+      create(:lecture, event: @event, start_time: start_time + 2.hours, end_time: end_time + 2.hours, room: @room)
+      lecture = create(:lecture,
+                       event: @event, room: @room,
+                       start_time: Time.current - 10.minutes,
+                       end_time: Time.current + 20.minutes)
 
       gl = GetLectures.new(@room)
       expect(gl.current).to eq(lecture)

--- a/spec/services/get_lectures_spec.rb
+++ b/spec/services/get_lectures_spec.rb
@@ -53,7 +53,7 @@ describe 'GetLectures' do
 
     before do
       @room = 'Empty'
-      @event = create(:event, start_date: Date.today, end_date: Time.zone.today + 5.days)
+      @event = create(:event, start_date: Time.zone.today, end_date: Time.zone.today + 5.days)
       travel_to @event.start_date_in_time_zone.change({ hour: 9 })
     end
 

--- a/spec/services/schedule_item_spec.rb
+++ b/spec/services/schedule_item_spec.rb
@@ -43,7 +43,7 @@ describe "ScheduleItem" do
   end
 
   def event_timezone_at(hour, min)
-    @event.start_date.to_time.in_time_zone(@event.time_zone).change({ hour: hour, min: min})
+    @event.start_date_in_time_zone.change({ hour: hour, min: min})
   end
 
   it '.new' do

--- a/spec/support/lectures.rb
+++ b/spec/support/lectures.rb
@@ -7,9 +7,9 @@ def build_lecture_schedule(event = nil)
 
   @event.days.each do |eday|
     (9..12).each do |hour|
-      start_time = eday.to_time.in_time_zone(@event.time_zone)
+      start_time = eday.in_time_zone(@event.time_zone)
                        .change(hour: hour, min: 0)
-      end_time = eday.to_time.in_time_zone(@event.time_zone)
+      end_time = eday.in_time_zone(@event.time_zone)
                  .change(hour: hour, min: 30)
       lecture_title = "Lecture at #{hour}"
       create(:lecture, event: @event, start_time: start_time,
@@ -22,10 +22,8 @@ end
 def add_lectures_on(date, room = 'A room')
   event = create(:event, start_date: date - 1.day)
   (9..12).each do |hour|
-    start_time = date.to_time.in_time_zone(event.time_zone)
-                     .change(hour: hour, min: 0)
-    end_time = date.to_time.in_time_zone(event.time_zone)
-               .change(hour: hour, min: 30)
+    start_time = date.in_time_zone(event.time_zone).change(hour: hour, min: 0)
+    end_time = date.in_time_zone(event.time_zone).change(hour: hour, min: 30)
     lecture_title = "Lecture at #{hour}"
     create(:lecture, event: event, start_time: start_time, end_time: end_time,
                      title: lecture_title, room: room)

--- a/spec/support/schedules.rb
+++ b/spec/support/schedules.rb
@@ -6,11 +6,9 @@ def build_schedule_template(event_type)
                                   name: 'Schedule Template Event')
   template_event.days.each do |eday|
     (9..12).each do |hour|
-      start_time = eday.to_time.in_time_zone(template_event.time_zone)
-                       .change(hour: hour, min: 0)
-      end_time = eday.to_time.in_time_zone(template_event.time_zone)
-                 .change(hour: hour, min: 30)
-      name = "#{eday.strftime("%A")} at #{start_time.strftime("%H:%M")}"
+      start_time = eday.in_time_zone(template_event.time_zone).change(hour: hour, min: 0)
+      end_time = eday.in_time_zone(template_event.time_zone).change(hour: hour, min: 30)
+      name = "#{eday.strftime('%A')} at #{start_time.strftime('%H:%M')}"
       create(:schedule, event: template_event, start_time: start_time,
                         end_time: end_time, name: name, updated_by: 'Staff',
                         staff_item: true, lecture_id: nil)


### PR DESCRIPTION
This PR attempts to fix most of the tests that fail due to time zone difference resulting in mismatched days of events and schedules as well as provides a bit of refactoring on tabulation, double quote usage and code duplication. Time based fails are fixed, but there are still other failing tests.


*The reason why tests failed: `#to_time` converting firstly to local time, and then `#in_time_zone` converting to another one. In some cases as this one it leads to date change*
<img width="476" alt="Screen Shot 2023-01-11 at 1 43 15 PM" src="https://user-images.githubusercontent.com/28920197/212302937-8f4d9581-b815-443b-b9db-62f649b9aa7b.png">
<img width="419" alt="Screen Shot 2023-01-11 at 1 48 54 PM" src="https://user-images.githubusercontent.com/28920197/212302930-9dc2d9f0-cddf-48ff-b6de-158fe9f6da62.png">
