### PR TITLE
Schedule and event locations dropdown v2

### DIFF
--- a/app/dashboards/event_dashboard.rb
+++ b/app/dashboards/event_dashboard.rb
@@ -25,7 +25,7 @@ class EventDashboard < Administrate::BaseDashboard
     end_date: Field::DateTime.with_options(format: "%Y-%m-%d"),
     event_type: Field::String.with_options(searchable: true),
     event_format: Field::Select.with_options(collection: event_formats),
-    location: Field::String.with_options(searchable: true),
+    location: Field::Select.with_options(collection: GetSetting.locations),
     description: Field::Text.with_options(searchable: true),
     press_release: Field::Text.with_options(searchable: true),
     max_participants: Field::Number,

--- a/app/dashboards/schedule_dashboard.rb
+++ b/app/dashboards/schedule_dashboard.rb
@@ -15,7 +15,7 @@ class ScheduleDashboard < Administrate::BaseDashboard
     end_time: Field::DateTime.with_options(format: "%H:%M"),
     name: Field::String,
     description: Field::Text,
-    location: Field::String,
+    location: ScheduleLocationSelect,
     updated_by: Field::String,
     created_at: Field::DateTime,
     updated_at: Field::DateTime,

--- a/app/fields/schedule_location_select.rb
+++ b/app/fields/schedule_location_select.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class ScheduleLocationSelect < Administrate::Field::Select
+  def to_partial_path
+    "/fields/#{Administrate::Field::Select.field_type}/#{page}"
+  end
+
+  private
+
+  def collection
+    GetSetting.location_rooms(resource&.event&.location)
+  end
+end

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -114,4 +114,8 @@ module EventsHelper
   def event_cancelled?(event)
     return ' class="cancelled"'.html_safe if event.cancelled
   end
+
+  def location_options
+    GetSetting.locations || []
+  end
 end

--- a/app/helpers/schedule_helper.rb
+++ b/app/helpers/schedule_helper.rb
@@ -71,4 +71,8 @@ module ScheduleHelper
       event_schedule_path
     end
   end
+
+  def schedule_location_options(schedule)
+    GetSetting.location_rooms(schedule.event.location)
+  end
 end

--- a/app/helpers/settings_helper.rb
+++ b/app/helpers/settings_helper.rb
@@ -26,4 +26,8 @@ module SettingsHelper
     end
     address
   end
+
+  def array_to_s(values)
+    '[' + values.join(', ') + ']'
+  end
 end

--- a/app/services/get_setting.rb
+++ b/app/services/get_setting.rb
@@ -124,7 +124,12 @@ class GetSetting
     return [] unless location_name
 
     rooms = location(location_name, 'rooms') || []
-    rooms.gsub(/^\[|"|'|\]$/, '').split(',').map(&:strip) if rooms.is_a?(String)
+
+    if rooms.is_a?(String)
+      rooms.gsub(/^\[|"|'|\]$/, '').split(',').map(&:strip)
+    else
+      rooms
+    end
   end
 
   def self.default_location

--- a/app/services/get_setting.rb
+++ b/app/services/get_setting.rb
@@ -120,6 +120,13 @@ class GetSetting
     Setting.Locations[location]['Country']
   end
 
+  def self.location_rooms(location_name)
+    return [] unless location_name
+
+    rooms = location(location_name, 'rooms') || []
+    rooms.gsub(/^\[|"|'|\]$/, '').split(',').map(&:strip) if rooms.is_a?(String)
+  end
+
   def self.default_location
     Setting.Locations.first.first
   end

--- a/app/services/setting_updater.rb
+++ b/app/services/setting_updater.rb
@@ -37,8 +37,7 @@ class SettingUpdater
     if @setting.value.is_a?(Hash)
       @setting.value.each do |param_name, param_value|
         if param_value.to_s.match?(/^\[(.+)\]$/)
-          param_value = param_value.gsub(/^\[|"|'|\]$/, '').
-            split(',').map(&:strip)
+          param_value = param_value.gsub(/^\[|"|'|\]$/, '').split(',').map(&:strip)
           @setting.value = @setting.value.merge(param_name => param_value)
         end
       end

--- a/app/views/events/_admin_form.html.erb
+++ b/app/views/events/_admin_form.html.erb
@@ -77,7 +77,7 @@
           <div class="col-lg-2">
             <%= f.label :location %>
             <div style="width: 6em;">
-              <%= f.select(:location, GetSetting.locations, {}, { class: 'form-control' }) %>
+              <%= f.select(:location, location_options, {}, { class: 'form-control' }) %>
             </div>
           </div>
           <div class="col-lg-2">

--- a/app/views/events/_event_edit_items.html.erb
+++ b/app/views/events/_event_edit_items.html.erb
@@ -7,6 +7,9 @@
   <% if field_name == 'short_name' %>
     <%= form.label 'Shorter Event Name to appear on name tags (must be under 68 characters)' %>
     <%= form.text_field field_name, maxlength: 67, class: 'form-control' %>
+  <% elsif field_name == 'location' %>
+    <%= form.label "#{field_name.titleize}" %>
+    <%= form.select field_name, location_options, {}, {class: 'form-control'} %>
   <% else %>
     <%= form.label "#{field_name.titleize}" %>
     <% if %w(description press_release).include?(field_name) %>

--- a/app/views/schedule/_form.html.erb
+++ b/app/views/schedule/_form.html.erb
@@ -132,7 +132,7 @@
     <div class="row">
       <div class="col form-group">
         <%= f.label :location %>:
-        <%= f.text_field :location, class: 'form-control' %>
+        <%= f.select :location, schedule_location_options(@schedule), {selected: @schedule.location}, {class: 'form-control'} %>
       </div>
     </div>
 

--- a/app/views/settings/_locations_form.html.erb
+++ b/app/views/settings/_locations_form.html.erb
@@ -13,8 +13,7 @@
               <label>Location:</label><br>
             </div>
           <div class="col-md-2">
-          <p><%= var_field.text_field 'new_key', size: 5, value: key,
-                  class: 'form-control input-sm' %></p>
+            <p><%= var_field.text_field 'new_key', size: 5, value: key, class: 'form-control input-sm' %></p>
           </div>
         </div>
         <% if values.is_a?(Hash) && !values.blank? %>
@@ -25,8 +24,8 @@
               <%= var_field.time_zone_select 'Timezone', ActiveSupport::TimeZone.us_zones,
                 { default: field_value }, { class: 'form-control' } %>
             <% else %>
-              <%= var_field.text_field field_name, value: field_value,
-                class: 'form-control' %>
+              <% field_value = array_to_s(field_value) if field_value.is_a?(Array) %>
+              <%= var_field.text_field field_name, value: field_value, class: 'form-control' %>
             <% end %>
             </p>
           <% end %><!-- values -->

--- a/app/views/settings/edit.html.erb
+++ b/app/views/settings/edit.html.erb
@@ -1,12 +1,8 @@
 <%= render "settings_nav" %>
 <div class="tab" id="settings-tab">
-  <%= form_for(@setting, url: setting_path(@setting.var), method: 'patch') do
-      |setting_form| %>
-    <% if lookup_context.exists?("#{@setting.var.downcase}_form",
-        ['settings/'], true) %>
-
-      <%= render partial: "#{@setting.var.downcase}_form",
-                locals: { setting_form: setting_form } %>
+  <%= form_for(@setting, url: setting_path(@setting.var), method: 'patch') do |setting_form| %>
+    <% if lookup_context.exists?("#{@setting.var.downcase}_form", ['settings/'], true) %>
+      <%= render partial: "#{@setting.var.downcase}_form", locals: { setting_form: setting_form } %>
     <% else %>
       <%= render partial: 'edit_form',locals: { setting_form: setting_form } %>
     <% end %>

--- a/config/locations.yml
+++ b/config/locations.yml
@@ -1,0 +1,48 @@
+---
+locations:
+  BIRS:
+    rooms:
+      - TCPL 201
+      - TCPL 202
+      - Online
+      - Vistas Dining
+      - TCPL Foyer
+      - TCPL Lounge
+      - Front Desk - Professional Development Centre
+      - Banff National Park
+      - Other (See Description)
+  BIRS-JP:
+    rooms:
+      - Kiguli Room
+      - Vermilion Room
+      - Hotel Front Desk
+      - Juniper Bistro
+      - Other (See Description)
+  CMO:
+    rooms:
+      - Hotel Hacienda Los Laureles
+      - Conference Room San Felipe
+      - Online
+      - Restaurant Hotel Hacienda Los Laureles
+      - Oaxaca
+      - Other (See Description)
+  UBCO:
+    rooms:
+      - Main Meeting Room - TBA
+      - Online
+      - Front Desk Skeena
+      - Sunshine - Administration Building
+      - Lounge - TBA
+      - Other (See Description)
+  IMAG:
+    rooms:
+      - Front Desk - Hotel Granada Center
+      - Main Meeting Room - Calle Rector López Argüeta
+      - Restaurant - Hotel Granada Center
+      - Other (See Description)
+  IASM:
+    rooms:
+      - Front Desk - Xianghu Lake National Tourist Resort
+      - Main Meeting Room - TBA
+      - Restaurant - TBA
+      - Other (See Description)

--- a/lib/tasks/sync_locations.rake
+++ b/lib/tasks/sync_locations.rake
@@ -36,7 +36,7 @@ namespace :sync_locations do
   end
 
   def yml_path
-    @yml_path ||= Rails.root.join('lib', 'assets', 'locations.yml')
+    @yml_path ||= Rails.root.join('config', 'locations.yml')
   end
 
   desc 'Makes sure that default locations and rooms are up to date'

--- a/lib/tasks/sync_locations.rake
+++ b/lib/tasks/sync_locations.rake
@@ -1,0 +1,66 @@
+# Copyright (c) 2023 Banff International Research Station
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this
+# software and associated documentation files (the "Software"), to deal in the Software
+# without restriction, including without limitation the rights to use, copy, modify,
+# merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to the following
+# conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies
+# or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+# PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+# CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+# OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+# Syncs default locations
+namespace :sync_locations do
+  task default: 'sync_locations:rooms'
+
+  def location_setting
+    @location_setting ||= Setting.find_by(var: 'Locations')
+  end
+
+  FileNotFoundError = StandardError
+
+  def yml_settings
+    return @yml_settings if defined?(@yml_settings)
+
+    raise FileNotFoundError unless File.exist?(yml_path)
+
+    @yml_settings = YAML.load_file(yml_path)
+  end
+
+  def yml_path
+    @yml_path ||= Rails.root.join('lib', 'assets', 'locations.yml')
+  end
+
+  desc 'Makes sure that default locations and rooms are up to date'
+  task rooms: :environment do
+    locations = yml_settings['locations']
+    db_locations = location_setting.value.dup
+
+    locations.each do |name, settings|
+      if db_locations[name]
+        p "Updating rooms for #{name}"
+        db_locations[name]['rooms'] = settings['rooms']
+      else
+        p "Did not found #{name} in site settings, doing nothing..."
+        next
+      end
+    end
+
+    begin
+      location_setting.update!(value: db_locations)
+      p 'Saved location rooms'
+    rescue StandardError => e
+      p "Error occurred: #{e}"
+    end
+  rescue FileNotFoundError
+    p "Did not found YAML file at #{yml_path}."
+  end
+end

--- a/spec/features/admin/admin_event_dashboard_spec.rb
+++ b/spec/features/admin/admin_event_dashboard_spec.rb
@@ -8,11 +8,11 @@ require 'rails_helper'
 
 describe 'Events Admin Dashboard', type: :feature do
   before do
-  	@event = create(:event)
-  	person = create(:person)
-  	create(:membership, event: @event, person: person, role: 'Organizer')
+    @event = create(:event)
+    person = create(:person)
+    create(:membership, event: @event, person: person, role: 'Organizer')
 
-  	@member_user = create(:user,email: person.email,person: person, role: 0)
+    @member_user = create(:user,email: person.email,person: person, role: 0)
     @staff_user = create(:user, :staff)
     @admin_user = create(:user, :admin)
     @super_admin_user = create(:user, :super_admin)
@@ -23,21 +23,21 @@ describe 'Events Admin Dashboard', type: :feature do
   end
 
   def fill_in_new_events_fields
-  	fill_in 'Code', with: '23w0001'
-	  fill_in 'Name', with: '5 Day Workshop Schedule Template'
-	  fill_in "Short name", with: 'Schedule template'
-	  fill_in 'Start date', with: Time.now + 1.days
-	  fill_in 'End date', with: Time.now + 3.days
-	  fill_in 'Event type', with: 'Summer School'
-	  fill_in 'Location', with: 'EO'
-	  fill_in 'Description', with: 'Description for testing purposes'
-	  fill_in 'Max participants', with: 5
-	  fill_in 'Door code', with: 12
-	  fill_in 'Updated by', with: 'Capybara'
+    fill_in 'Code', with: '23w0001'
+    fill_in 'Name', with: '5 Day Workshop Schedule Template'
+    fill_in "Short name", with: 'Schedule template'
+    fill_in 'Start date', with: Time.now + 1.days
+    fill_in 'End date', with: Time.now + 3.days
+    fill_in 'Event type', with: 'Summer School'
+    select 'EO', from: 'Location'
+    fill_in 'Description', with: 'Description for testing purposes'
+    fill_in 'Max participants', with: 5
+    fill_in 'Door code', with: 12
+    fill_in 'Updated by', with: 'Capybara'
     select 'Mountain Time (US & Canada)', from: 'event[time_zone]'
-	  check 'Template'
+    check 'Template'
 
-	  click_on('Create Event')
+    click_on('Create Event')
   end
 
   context 'As a not-logged in user' do
@@ -83,17 +83,17 @@ describe 'Events Admin Dashboard', type: :feature do
     end
     it "should display admin events dashboard" do
       expect(page).to have_current_path(admin_events_path)
-	  end
+    end
 
-	  it "can create new event" do
-	    click_link('New event')
+    it "can create new event" do
+      click_link('New event')
 
-	    fill_in_new_events_fields
+      fill_in_new_events_fields
 
-	    visit admin_events_path
+      visit admin_events_path
 
-	    expect(page).to have_content('23w0001')
-	  end
+      expect(page).to have_content('23w0001')
+    end
   end
 
   context 'As a super_admin user' do

--- a/spec/features/schedule_add_items_spec.rb
+++ b/spec/features/schedule_add_items_spec.rb
@@ -28,7 +28,7 @@ describe "Adding a Schedule Item", type: :feature do
   it 'adds an item to the schedule' do
     click_link "Add an item on #{@weekday}"
     page.fill_in 'schedule_name', with: 'New item for test schedule'
-    page.fill_in 'schedule_location', with: 'Somewhere'
+    page.select 'Room 3', from: 'schedule_location'
     click_button 'Add New Schedule Item'
 
     expect(page).to have_content '"New item for test schedule" was successfully
@@ -46,7 +46,7 @@ describe "Adding a Schedule Item", type: :feature do
 
     click_link "Add an item on #{weekday}"
     page.fill_in 'schedule_name', with: 'Testing TZ'
-    page.fill_in 'schedule_location', with: 'Australia'
+    page.select 'Room 3', from: 'schedule_location'
     click_button 'Add New Schedule Item'
 
     new_item = event.schedules.detect { |s| s.name == 'Testing TZ' }
@@ -64,7 +64,7 @@ describe "Adding a Schedule Item", type: :feature do
     new_day = @day + 1.days
     page.select new_day.strftime("%A"), from: 'schedule_day'
     page.fill_in 'schedule_name', with: 'Another item for testing'
-    page.fill_in 'schedule_location', with: 'Somewhere'
+    page.select 'Room 3', from: 'schedule_location'
     click_button 'Add New Schedule Item'
     new_item = @event.schedules.detect {|s| s.name == 'Another item for testing'}
     expect(new_item.start_time.to_date).to eq(new_day)
@@ -73,13 +73,13 @@ describe "Adding a Schedule Item", type: :feature do
   it 'adding an item that overlaps with another item (in a different room) produces a warning notice' do
     click_link "Add an item on #{@weekday}"
     page.fill_in 'schedule_name', with: 'Item One'
-    page.fill_in 'schedule_location', with: 'Location One'
+    page.select 'Room 3', from: 'schedule_location'
     page.select '09', from: 'schedule_start_time_4i'
     page.select '10', from: 'schedule_end_time_4i'
     click_button 'Add New Schedule Item'
 
     page.fill_in 'schedule_name', with: 'Item Two'
-    page.fill_in 'schedule_location', with: 'Location Two'
+    page.select 'Room 2', from: 'schedule_location'
     page.select '09', from: 'schedule_start_time_4i'
     page.select '30', from: 'schedule_start_time_5i'
     page.select '10', from: 'schedule_end_time_4i'
@@ -94,7 +94,7 @@ describe "Adding a Schedule Item", type: :feature do
     expect(current_path).to eq(event_schedule_day_path(@event, @day))
 
     page.fill_in 'schedule_name', with: 'New item for test schedule'
-    page.fill_in 'schedule_location', with: 'Somewhere'
+    page.select 'Room 1', from: 'schedule_location'
     click_button 'Add New Schedule Item'
 
     expect(current_path).to eq(event_schedule_day_path(@event, @day))
@@ -107,7 +107,7 @@ describe "Adding a Schedule Item", type: :feature do
 
     click_link "Add an item on #{@weekday}"
     page.fill_in 'schedule_name', with: 'New item for test schedule'
-    page.fill_in 'schedule_location', with: 'Somewhere'
+    page.select 'Room 3', from: 'schedule_location'
     click_button 'Add New Schedule Item'
 
     expect(page.body).to have_text('was successfully scheduled')

--- a/spec/features/schedule_edit_item_spec.rb
+++ b/spec/features/schedule_edit_item_spec.rb
@@ -67,7 +67,7 @@ describe 'Editing a Schedule Item', type: :feature do
       page.select new_start.strftime('%M'), from: 'schedule_start_time_5i'
       page.select new_stop.strftime('%H'), from: 'schedule_end_time_4i'
       page.select new_stop.strftime('%M'), from: 'schedule_end_time_5i'
-      page.fill_in 'schedule_location', with: 'Elsewhere'
+      page.select 'Room 1', from: 'schedule_location'
 
       click_button 'Update Schedule'
       expect(find('div.alert-warning').text)
@@ -142,9 +142,9 @@ describe 'Editing a Schedule Item', type: :feature do
       end
 
       it 'updates the location of the item' do
-        page.fill_in 'schedule_location', with: 'In the woods'
+        page.select 'Room 2', from: 'schedule_location'
         click_button 'Update Schedule'
-        expect(Schedule.find(@item.id).location).to eq('In the woods')
+        expect(Schedule.find(@item.id).location).to eq('Room 2')
       end
 
       context 'If the "change_similar" option is selected on update' do
@@ -193,8 +193,8 @@ describe 'Editing a Schedule Item', type: :feature do
         end
 
         it 'updates the locations of similar items' do
-          new_location = 'A better spot for this'
-          page.fill_in 'schedule_location', with: new_location
+          new_location = 'Room 3'
+          page.select new_location, from: 'schedule_location'
           page.check('change_similar')
           click_button 'Update Schedule'
           expect(Schedule.find(@item.id).location).to eq(new_location)

--- a/spec/support/settings.rb
+++ b/spec/support/settings.rb
@@ -83,7 +83,8 @@ end
       'max_participants' => 42,
       'max_virtual' => 300,
       'max_observers' => 5,
-      'billing_codes' => "{'default' => 'EO1', 'USA' => 'EO2'}"
+      'billing_codes' => "{'default' => 'EO1', 'USA' => 'EO2'}",
+      'rooms' => ['Room 1', 'Room 2', 'Room 3'],
     }
   }
 # end


### PR DESCRIPTION
This PR adds the ability to select schedule location based on event's location. Select location fields were added to schedule form, admin schedule dashboard and admin event's dashboard

<img width="1062" alt="Screen Shot 2023-02-09 at 3 43 14 PM" src="https://user-images.githubusercontent.com/28920197/217776295-7593acfa-c469-4d76-bd39-4569ac7604ee.png">
<img width="561" alt="Screen Shot 2023-02-09 at 3 44 16 PM" src="https://user-images.githubusercontent.com/28920197/217776536-3960a2c4-6558-4ce3-8cb1-704d584b4a3a.png">
