### PR TITLE
Do not allow organizers to see event summary and generate report

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -356,7 +356,7 @@ GEM
     rb-fsevent (0.11.0)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rbnacl (6.0.1)
+    rbnacl (7.1.1)
       ffi
     rdoc (6.3.3)
     reek (6.0.6)
@@ -545,7 +545,7 @@ DEPENDENCIES
   rails (~> 5.2.4.5)
   rails-controller-testing
   rails-settings-cached (= 0.7.2)
-  rbnacl (~> 6.0)
+  rbnacl (~> 7.0)
   rest-client
   rollbar
   rspec-rails

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -21,7 +21,7 @@ class ReportsController < ApplicationController
 
   # GET /events/:event_id/summary
   def summary
-    authorize @event, :generate_report?
+    authorize @event, :see_summary?
 
     result = ExportEventMembers.new(event_ids: [@event.id], options: summary_options).call(to: :table)
 

--- a/app/policies/event_policy.rb
+++ b/app/policies/event_policy.rb
@@ -120,12 +120,10 @@ class EventPolicy
   end
 
   def generate_report?
-    organizers_and_staff
+    staff_and_admins
   end
 
-  def see_summary?
-    organizers_and_staff
-  end
+  alias see_summary? generate_report?
 
   private
 

--- a/spec/features/reports_spec.rb
+++ b/spec/features/reports_spec.rb
@@ -42,12 +42,6 @@ RSpec.describe 'Reports', type: :feature do
           it { expect(page.response_headers['Content-Type']).to eq('text/csv') }
         end
 
-        context 'when organizer' do
-          let(:user) { organizer }
-
-          it { expect(page.response_headers['Content-Type']).to eq('text/csv') }
-        end
-
         context 'when staff' do
           let(:user) { staff }
 
@@ -58,6 +52,13 @@ RSpec.describe 'Reports', type: :feature do
       context 'when access is not allowed' do
         context 'when participant' do
           let(:user) { participant }
+
+          it { expect(page).not_to have_text('Get report') }
+          it { expect(page).to have_text('Access denied') }
+        end
+
+        context 'when organizer' do
+          let(:user) { organizer }
 
           it { expect(page).not_to have_text('Get report') }
           it { expect(page).to have_text('Access denied') }
@@ -219,21 +220,6 @@ RSpec.describe 'Reports', type: :feature do
         EventMembersPresenter::SUMMARY_FIELDS.each do |field|
           expect(page).to have_text(key_to_header(field))
         end
-      end
-    end
-
-    context 'when submitting form' do
-      before do
-        click_on 'See summary'
-      end
-
-      let(:event_membership) { event.memberships.first }
-      let(:link) { first('.clickable-row')[:'data-href'] }
-
-      it('shows a table') { expect(page.response_headers['Content-Type']).to eq('text/html; charset=utf-8') }
-
-      it 'has a link to edit a membership' do
-        expect(link).to eq(edit_event_membership_path(event, event_membership))
       end
     end
   end


### PR DESCRIPTION
This PR patches the ability for organizers to see event summary and report and removes dead specs