### PR TITLE
Split confirmed members count

### DIFF
--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -126,12 +126,22 @@ module EventsHelper
   end
 
   def onsite_confirmed_count(event)
+    return events_hash["#{event.id}_onsite_confirmed"] if events_hash["#{event.id}_onsite_confirmed"]
+
     events_hash["#{event.id}_onsite_confirmed"] = Membership.where(
       attendance: 'Confirmed', role: Membership::IN_PERSON_ROLES, event: event
     ).count
   end
 
   def virtual_confirmed_count(event)
-    event.confirmed_count - events_hash["#{event.id}_onsite_confirmed"]
+    return events_hash["#{event.id}_virtual_confirmed"] if events_hash["#{event.id}_virtual_confirmed"]
+
+    events_hash["#{event.id}_virtual_confirmed"] = Membership.where(
+      attendance: 'Confirmed', role: Membership::ONLINE_ROLES, event: event
+    ).count
+  end
+
+  def observers_count(event)
+    event.confirmed_count - virtual_confirmed_count(event) - onsite_confirmed_count(event)
   end
 end

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -120,4 +120,18 @@ module EventsHelper
   def location_options
     GetSetting.locations || []
   end
+
+  def events_hash
+    @events_hash ||= {}
+  end
+
+  def onsite_confirmed_count(event)
+    events_hash["#{event.id}_onsite_confirmed"] = Membership.where(
+      attendance: 'Confirmed', role: Membership::IN_PERSON_ROLES, event: event
+    ).count
+  end
+
+  def virtual_confirmed_count(event)
+    event.confirmed_count - events_hash["#{event.id}_onsite_confirmed"]
+  end
 end

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -5,7 +5,7 @@
     	 <tr>
     		<th><%= image_tag('globe.png', alt: 'Location') %></th><th>Code</th><th class="d-none d-sm-table-cell">Workshop Name</th>
         <th colspan="2" class="d-none d-lg-table-cell"></th><th>Dates</th>
-        <th class="d-none d-sm-table-cell"><a title="Confirmed Participants">#</a></th>
+        <th class="d-none d-sm-table-cell"><a title="Confirmed Participants">Onsite/Virtual</a></th>
     	 </tr>
       </thead>
       <tbody>
@@ -17,7 +17,7 @@
     	    <td width="125" class="d-none d-lg-table-cell"><%= link_to '<i class="fa fa-calendar fa-fw"></i> Schedule'.html_safe, event_schedule_index_path(event) %></td>
     	    <td width="125" class="d-none d-lg-table-cell"><%= link_to '<i class="fa fa-users fa-fw"></i> Members'.html_safe, event_memberships_path(event) %></td>
     	    <td width="125"><%= event.dates %></td>
-    	    <td class="d-none d-sm-table-cell confirmed"><%= event.confirmed_count %></td>
+    	    <td class="d-none d-sm-table-cell confirmed"><%= "#{onsite_confirmed_count(event)}/#{virtual_confirmed_count(event)}" %></td>
     	</tr>
       <% end %>
       <tr>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -5,7 +5,7 @@
     	 <tr>
     		<th><%= image_tag('globe.png', alt: 'Location') %></th><th>Code</th><th class="d-none d-sm-table-cell">Workshop Name</th>
         <th colspan="2" class="d-none d-lg-table-cell"></th><th>Dates</th>
-        <th class="d-none d-sm-table-cell"><a title="Confirmed Participants">Onsite/Virtual</a></th>
+        <th class="d-none d-sm-table-cell"><a title="Confirmed Participants">Onsite/Virtual/Observers</a></th>
     	 </tr>
       </thead>
       <tbody>
@@ -17,7 +17,7 @@
     	    <td width="125" class="d-none d-lg-table-cell"><%= link_to '<i class="fa fa-calendar fa-fw"></i> Schedule'.html_safe, event_schedule_index_path(event) %></td>
     	    <td width="125" class="d-none d-lg-table-cell"><%= link_to '<i class="fa fa-users fa-fw"></i> Members'.html_safe, event_memberships_path(event) %></td>
     	    <td width="125"><%= event.dates %></td>
-    	    <td class="d-none d-sm-table-cell confirmed"><%= "#{onsite_confirmed_count(event)}/#{virtual_confirmed_count(event)}" %></td>
+    	    <td class="d-none d-sm-table-cell confirmed"><%= "#{onsite_confirmed_count(event)}/#{virtual_confirmed_count(event)}/#{observers_count(event)}" %></td>
     	</tr>
       <% end %>
       <tr>


### PR DESCRIPTION
This PR splits confirmed members count on events home page to three numbers - confirmed on-site, confirmed virtual and observers
<img width="1508" alt="Screen Shot 2023-03-21 at 7 11 33 PM" src="https://user-images.githubusercontent.com/28920197/226616212-ab3e668a-73f0-43af-8a24-11fdb46ede89.png">
