### PR TITLE
Disallow changing Virtual Participant to Participant role after Tuesday before workshop

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -123,6 +123,11 @@ class Event < ApplicationRecord
                 "must be set to one of #{event_formats.join(', ')}")
   end
 
+  def lock_date
+    # Stop accepting some changes after Tuesday on the workshop week
+    (start_date.beginning_of_week + 1.day).end_of_day
+  end
+
   private
 
   def update_legacy_db

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -37,6 +37,7 @@ en:
       something_went_wrong: Something went wrong
     error_messages:
       no_options_selected: Please select at least one option
+      role_change_to_physical_after_lock: "Cannot change role to Participant after event lock date %{lock_date}. Please contact BIRS staff"
   events:
     formats:
       hybrid: Hybrid

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -55,6 +55,9 @@ RSpec.configure do |config|
 
   # Render views so we can test the correct response
   config.render_views
+
+  # Allows to travel_to Time inside block
+  config.include ActiveSupport::Testing::TimeHelpers
 end
 
 


### PR DESCRIPTION
This PR will disallow organizers to switch virtual participant role to participant after Tuesday before workshop week