### PR TITLE
Fix rsvp deadline in invitations

### DIFF
--- a/app/helpers/memberships_helper.rb
+++ b/app/helpers/memberships_helper.rb
@@ -113,8 +113,8 @@ module MembershipsHelper
     invited_by.html_safe
   end
 
-  def rsvp_by(event, invited_on)
-    rsvp_by = RsvpDeadline.new(event, invited_on).rsvp_by
+  def rsvp_by(event, invited_on, membership = nil)
+    rsvp_by = RsvpDeadline.new(event, invited_on, membership).rsvp_by
     DateTime.parse(rsvp_by).strftime('%b. %e, %Y')
   end
 
@@ -139,7 +139,7 @@ module MembershipsHelper
 
   def show_reply_by_date(member)
     invited_on = last_invited(member, member.event.time_zone)
-    DateTime.parse(rsvp_by(member.event, invited_on)).strftime('%Y-%m-%d')
+    DateTime.parse(rsvp_by(member.event, invited_on, member)).strftime('%Y-%m-%d')
   end
 
   def show_invited_on_date(member, no_td = false)

--- a/app/helpers/memberships_helper.rb
+++ b/app/helpers/memberships_helper.rb
@@ -303,7 +303,7 @@ module MembershipsHelper
       #{pluralize_no_count(physical_spots, 'in-person spot')}, and
       <strong>#{virtual_spots}/#{max_virtual}</strong>
       #{pluralize_no_count(virtual_spots, 'virtual spot')} left
-      (includes confirmed + invited)."
+      (includes confirmed + undecided + invited)."
 
     msg << cancellations_msg(physical_spots, virtual_spots)
   end

--- a/app/helpers/memberships_helper.rb
+++ b/app/helpers/memberships_helper.rb
@@ -154,7 +154,7 @@ module MembershipsHelper
         data-target="#invitations-' + member.id.to_s + '"
         data-trigger="hover focus" data-content="By ' +
         format_invited_by(member) + '<br><b>Reply-by date:</b> ' +
-        rsvp_by(member.event, invited_on) +
+        rsvp_by(member.event, invited_on, member) +
         '" >'+ member.invited_on.strftime('%Y-%m-%d') +'</a>'
     end
     unless member.invite_reminders.blank?

--- a/app/lib/rsvp_deadline.rb
+++ b/app/lib/rsvp_deadline.rb
@@ -1,4 +1,4 @@
-# ./app/services/rsvp_deadline.rb
+# ./app/lib/rsvp_deadline.rb
 #
 # Copyright (c) 2018 Banff International Research Station
 #

--- a/app/views/memberships/invite.html.erb
+++ b/app/views/memberships/invite.html.erb
@@ -9,7 +9,7 @@
 <% else %>
   <div id="reply-by">
     <span id="reply-by-date">
-      <strong>Reply by date:</strong> <%= RsvpDeadline.new(@event).rsvp_by %>
+      <strong>About reply by date:</strong>
       <span id="rsvp-by-icon"><a href="#" data-toggle="modal" data-target="#about-reply-by"><i class="fa fa-lg fa-fw fa-question-circle"></i></a></span>
     </span>
     <span class="pull-right" id="limits-message"><%= add_limits_message %></span>

--- a/spec/lib/rsvp_deadline_spec.rb
+++ b/spec/lib/rsvp_deadline_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe RsvpDeadline do
     context '3m 5d from now' do
       let(:start_date) { Date.today + 3.month + 5.days }
 
-      it('sets deadline 4w from now') { expect(rsvp_by).to eq(to_rsvp_format(4.weeks.from_now)) }
+      it('sets deadline 21d from now') { expect(rsvp_by).to eq(to_rsvp_format(21.days.from_now)) }
     end
 
     context 'less than 3m 5d, but more than 2m from now' do

--- a/spec/lib/rsvp_deadline_spec.rb
+++ b/spec/lib/rsvp_deadline_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe RsvpDeadline do
+  subject(:rsvp_by) { described_class.new(event, invited_on, membership).rsvp_by }
+
+  let(:event) { create(:event, start_date: start_date, end_date: end_date, event_format: 'Hybrid') }
+  let(:membership) { create(:membership) }
+  let(:invited_on) { DateTime.current }
+  let(:end_date) { start_date + 5.days }
+
+  def to_rsvp_format(date)
+    date.strftime('%B %-d, %Y')
+  end
+
+  context 'when event is' do
+    context 'more than 3m 5d from now' do
+      let(:start_date) { Date.today + 3.month + 6.days }
+
+      it('sets deadline 4w from now') { expect(rsvp_by).to eq(to_rsvp_format(4.weeks.from_now)) }
+    end
+
+    context '3m 5d from now' do
+      let(:start_date) { Date.today + 3.month + 5.days }
+
+      it('sets deadline 4w from now') { expect(rsvp_by).to eq(to_rsvp_format(4.weeks.from_now)) }
+    end
+
+    context 'less than 3m 5d, but more than 2m from now' do
+      let(:start_date) { Date.today + 2.month + 10.days }
+
+      it('sets deadline 21d from now') { expect(rsvp_by).to eq(to_rsvp_format(21.days.from_now)) }
+    end
+
+    context '2m from now' do
+      let(:start_date) { Date.today + 2.month }
+
+      it('sets deadline 10d from now') { expect(rsvp_by).to eq(to_rsvp_format(10.days.from_now)) }
+    end
+
+    context 'less than 2m, but more than 10d from now' do
+      let(:start_date) { Date.today + 1.month + 15.days }
+
+      it('sets deadline 10d from now') { expect(rsvp_by).to eq(to_rsvp_format(10.days.from_now)) }
+    end
+
+    context '10d from now' do
+      let(:start_date) { Date.today.beginning_of_week + 10.days }
+
+      it 'sets deadline to Tuesday before event' do
+        expect(rsvp_by).to eq(to_rsvp_format(start_date.prev_occurring(:tuesday)))
+      end
+    end
+
+    context 'less than 10d from now' do
+      let(:start_date) { Date.today.beginning_of_week + 9.days }
+
+      it 'sets deadline to Tuesday before event' do
+        expect(rsvp_by).to eq(to_rsvp_format(start_date.prev_occurring(:tuesday)))
+      end
+    end
+  end
+
+  context 'when Tuesday before the event is in the past' do
+    let(:start_date) { Date.today.beginning_of_week }
+
+    it 'sets deadline to Tuesday before event' do
+      expect(rsvp_by).to eq(to_rsvp_format(Date.tomorrow))
+    end
+  end
+end


### PR DESCRIPTION
This PR fixes the inconsistency when the reply by date is first calculated, and then displayed wrong on the invitations page. It also covers reply by calculations with specs, and moves `rsvp_deadline` from services to lib folder.