### PR TITLE
Revert visibility behaviour

### DIFF
--- a/app/policies/event_policy.rb
+++ b/app/policies/event_policy.rb
@@ -89,8 +89,10 @@ class EventPolicy
     organizers_and_staff
   end
 
-  def view_attendance_status?
-    true if current_user
+  def view_attendance_status?(status)
+    return true if organizers_and_staff
+
+    ['Confirmed'].include?(status) if current_user
   end
 
   def show_email_buttons?(status)

--- a/app/views/memberships/index.html.erb
+++ b/app/views/memberships/index.html.erb
@@ -10,7 +10,7 @@
   <!-- Membership list, one per type of attendance status  -->
   <div class="d-flex flex-wrap align-content-stretch align-self-start">
   <% @memberships.each do |status, members| %>
-    <% if policy(@event).view_attendance_status? %>
+    <% if policy(@event).view_attendance_status?(status) %>
     <div class="card p-2 members-list <%= print_section?(status) %> <%= status.parameterize %>-members">
       <h4 class="card-title">
         <%= status_with_icon(status) %> Members (<%= members.size %>)


### PR DESCRIPTION
Participants should only be able to see confirmed participants. An inadvertent change in #48 broke this behaviour