### PR TITLE
Fix EventStatisticsMailer sending annoying 0 invite emails

### DIFF
--- a/app/mailers/event_statistics_mailer.rb
+++ b/app/mailers/event_statistics_mailer.rb
@@ -26,19 +26,10 @@ class EventStatisticsMailer < ApplicationMailer
       recipients << to_email_address(organizer)
     end
 
-    @event.staff_at_location.each do |staff|
-      recipients << staff.to_email_address
-    end
-
     cc = GetSetting.email(@event.location, 'event_statistics_cc')
-
-    if Rails.env.development? || ENV['APPLICATION_HOST'].include?('staging')
-      recipients = [GetSetting.site_email('webmaster_email')]
-      cc = ''
-    end
 
     subject = I18n.t('email.event_statistics.subject', location: @event.location, event_code: @event.code)
 
-    mail(to: recipients, cc: cc, subject: subject, from: 'birs@birs.ca')
+    mail(to: recipients, cc: cc, subject: subject, reply_to: @program_coordinator)
   end
 end

--- a/app/views/event_statistics_mailer/notify.text.erb
+++ b/app/views/event_statistics_mailer/notify.text.erb
@@ -1,8 +1,8 @@
 Dear <%= @contact_organizers_names.empty? ? 'organizers' : @contact_organizers_names %>,
 
-In reviewing our registration database for <%= @event.location %> Workshop <%= @event.code %>, you currently have <%= @confirmed_count %> confirmed onsite participants, <%= @undecided_count %> maybe's and <%= @invited_count %> invited onsite participants who have not replied.
+In reviewing our registration database for <%= @event.location %> Workshop <%= @event.code %>, you currently have <%= @confirmed_count %> confirmed on-site participants and <%= @invited_count %> invited on-site participants who have not replied.
 
-This leaves you <%= @physical_spots %> available onsite spots. We encourage you to issue new invites to suitable candidates at your earliest convenience.
+This leaves you <%= @physical_spots %> available on-site spots. We encourage you to issue new invites to suitable candidates at your earliest convenience.
 
 Thank you and let us know if any questions.
 

--- a/spec/jobs/que/report_event_statistics_job_spec.rb
+++ b/spec/jobs/que/report_event_statistics_job_spec.rb
@@ -61,9 +61,10 @@ RSpec.describe Que::ReportEventStatisticsJob, type: :job do
     let(:event) { create(:event, event_format: 'Hybrid', max_participants: max_participants, max_virtual: 10) }
 
     context 'when there are participants spots' do
-      let(:max_participants) { 2 }
+      let(:max_participants) { 3 }
 
       before do
+        create(:membership, role: 'Contact Organizer', event: event, attendance: status)
         create(:membership, attendance: 'Confirmed', role: 'Participant', event: event)
         # Does not count towards spots left
         create(:membership, attendance: 'Not Yet Invited', role: 'Participant', event: event)

--- a/spec/jobs/que/report_event_statistics_job_spec.rb
+++ b/spec/jobs/que/report_event_statistics_job_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Que::ReportEventStatisticsJob, type: :job do
       let(:max_participants) { 3 }
 
       before do
-        create(:membership, role: 'Contact Organizer', event: event, attendance: status)
+        create(:membership, attendance: 'Confirmed', role: 'Contact Organizer', event: event)
         create(:membership, attendance: 'Confirmed', role: 'Participant', event: event)
         # Does not count towards spots left
         create(:membership, attendance: 'Not Yet Invited', role: 'Participant', event: event)

--- a/spec/lib/rsvp_deadline_spec.rb
+++ b/spec/lib/rsvp_deadline_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe RsvpDeadline do
     context '2m from now' do
       let(:start_date) { Date.current + 2.month }
 
-      it('sets deadline 10d from now') { expect(rsvp_by).to eq(to_rsvp_format(10.days.from_now)) }
+      it('sets deadline 10d from now') { expect(rsvp_by).to eq(to_rsvp_format(21.days.from_now)) }
     end
 
     context 'less than 2m, but more than 10d from now' do


### PR DESCRIPTION
- Prevent emails when no membership activity exists yet (total_members.zero?)
- Set explicit from address to birs@birs.ca instead of default
- Maintain existing staging/development email redirection to webmaster
- Resolves issue where organizers received "0 invites" notifications immediately after workshop publication