### PR TITLE
Fix test role change max redirect

### DIFF
--- a/spec/controllers/memberships_controller_spec.rb
+++ b/spec/controllers/memberships_controller_spec.rb
@@ -625,9 +625,7 @@ RSpec.describe MembershipsController, type: :controller do
             before do
               travel_to today
 
-              @event.update_columns(
-                max_virtual: @event.num_invited_virtual + 1
-              )
+              @event.update_attribute(:max_virtual, @event.num_invited_virtual + 1)
               @membership.update_attribute(:role, 'Virtual Participant')
               @event.update_attribute(:start_date, Date.today.beginning_of_week + 3.days)
 

--- a/spec/controllers/memberships_controller_spec.rb
+++ b/spec/controllers/memberships_controller_spec.rb
@@ -640,6 +640,9 @@ RSpec.describe MembershipsController, type: :controller do
               let(:today) { Date.today.beginning_of_week + 3.days }
 
               it 'disallows changing Virtual Participant role to Participant' do
+                @event.update_columns(
+                  max_virtual: @event.num_invited_virtual + 1
+                )
                 expect(@membership.reload.role).to eq('Virtual Participant')
               end
 

--- a/spec/controllers/memberships_controller_spec.rb
+++ b/spec/controllers/memberships_controller_spec.rb
@@ -625,6 +625,9 @@ RSpec.describe MembershipsController, type: :controller do
             before do
               travel_to today
 
+              @event.update_columns(
+                max_virtual: @event.num_invited_virtual + 1
+              )
               @membership.update_attribute(:role, 'Virtual Participant')
               @event.update_attribute(:start_date, Date.today.beginning_of_week + 3.days)
 
@@ -640,9 +643,6 @@ RSpec.describe MembershipsController, type: :controller do
               let(:today) { Date.today.beginning_of_week + 3.days }
 
               it 'disallows changing Virtual Participant role to Participant' do
-                @event.update_columns(
-                  max_virtual: @event.num_invited_virtual + 1
-                )
                 expect(@membership.reload.role).to eq('Virtual Participant')
               end
 

--- a/spec/controllers/memberships_controller_spec.rb
+++ b/spec/controllers/memberships_controller_spec.rb
@@ -625,7 +625,7 @@ RSpec.describe MembershipsController, type: :controller do
             before do
               travel_to today
 
-              @event.update_attribute(:max_virtual, @event.num_invited_virtual + 1)
+              @event.update_columns(max_virtual: GetSetting.max_virtual('EO'))
               @membership.update_attribute(:role, 'Virtual Participant')
               @event.update_attribute(:start_date, Date.today.beginning_of_week + 3.days)
 
@@ -1056,6 +1056,7 @@ RSpec.describe MembershipsController, type: :controller do
           end
 
           it 'does not invite Observer if max_observers is full' do
+            @event.update_columns(event_format: 'Physical')
             @event.max_participants = @event.num_invited_participants
             @event.max_virtual = @event.num_invited_virtual
             @event.max_observers = @event.num_invited_observers


### PR DESCRIPTION
These commits are meant to address some intermittent test failures. One of the tests looks at changing participant types before and after a lock date, but that can fail if there isn't enough free space in the type you are moving the participant to. The other test looks at attempting to add an observer when the max_observers limit has been reached. This was failing when the event was Hybrid. For now the test is restricted to Physical events. Separate tests should be added for Hybrid and Online events, but we need more details on how to handle observers for those.