### PR TITLE
fix: Add authorization check for custom_fields display

### DIFF
--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -113,8 +113,10 @@
           <% end %>
         </h2>
         <%= get_text(@event.press_release) %>
-        <% @event.custom_fields.order(position: :asc).each do |field| %>
-          <%= render 'custom_field', custom_field: field %>
+        <% if user_signed_in? && (policy(@event).event_staff? || current_user.is_organizer?(@event)) %>
+          <% @event.custom_fields.order(position: :asc).each do |field| %>
+            <%= render 'custom_field', custom_field: field %>
+          <% end %>
         <% end %>
         </div>
       </div>


### PR DESCRIPTION
Custom fields containing proposal data (Overview, Objectives, Novelty, Program Structure, Workshop Schedule) were being rendered publicly without any authorization check.