### PR TITLE
Don't email the double check for now

### DIFF
--- a/app/jobs/que/double_check_attendance_job.rb
+++ b/app/jobs/que/double_check_attendance_job.rb
@@ -8,8 +8,8 @@ module Que
       return unless @event.hybrid_or_physical?
 
       case step.to_sym
-      when :rsvp_one_month_before_event
-        rsvp_one_month_before_event
+      #when :rsvp_one_month_before_event
+      #  rsvp_one_month_before_event
       when :alert_staff
         alert_staff
       else


### PR DESCRIPTION
Just skip the double check emails for now. We need to pick apart what the double check was intended to do, but for now this should let us enable que again.