### PR TITLE
Restrict schedule visibility to event members and staff

### DIFF
--- a/app/controllers/schedule_controller.rb
+++ b/app/controllers/schedule_controller.rb
@@ -9,7 +9,7 @@ class ScheduleController < ApplicationController
   before_action :set_schedule, only: [:show, :update]
   before_action :set_lock_time, only: [:new, :edit, :update, :create]
 
-  before_action :authenticate_user!, except: [:index]
+  before_action :authenticate_user!
   after_action :flash_notice, only: [:create, :update, :edit]
 
 
@@ -18,12 +18,6 @@ class ScheduleController < ApplicationController
   def index
     @schedules = DefaultSchedule.new(@event, current_user).schedules
     @schedule_policy = Schedule.new(event: @event)
-
-    redirect_to sign_in_path if nothing_to_see_here(@schedules)
-  end
-
-  def nothing_to_see_here(schedules)
-    request.format.html? && schedules.empty? && !current_user
   end
 
   # POST /events/:event_id/schedule/schedule_publish

--- a/app/policies/default_schedule_policy.rb
+++ b/app/policies/default_schedule_policy.rb
@@ -19,4 +19,9 @@ class DefaultSchedulePolicy
     user.is_organizer?(event) || user.is_admin? ||
       (user.is_staff? && user.location == event.location)
   end
+
+  def can_view?
+    return false if user.nil?
+    allow? || user.is_member?(event)
+  end
 end

--- a/app/services/default_schedule.rb
+++ b/app/services/default_schedule.rb
@@ -22,6 +22,10 @@ class DefaultSchedule
     Pundit.policy(@current_user, self).allow?
   end
 
+  def can_view?
+    Pundit.policy(@current_user, self).can_view?
+  end
+
   def empty_or_default
     @schedules.empty? || only_default_entries
   end
@@ -88,6 +92,6 @@ class DefaultSchedule
 
   def published_schedule
     return false unless @event
-    authorized? || @event.publish_schedule
+    can_view?
   end
 end

--- a/app/views/schedule/index.html.erb
+++ b/app/views/schedule/index.html.erb
@@ -50,18 +50,7 @@
   <% if policy(Schedule.new(event: @event)).publish_schedule? %>
   <div id="event-code"><%= @event.code %></div>
   <div class="row schedule-buttons no-print">
-    <div class="col-md-6">
-      <div class="card card-body bg-light publish_schedule_controls">
-        <label class="switch">
-          <%= check_box_tag(:publish_schedule, @event.publish_schedule, @event.publish_schedule) %>
-          <span class="slider round"></span>
-        </label>
-        <div id="publish_schedule_text">Publish Schedule (OFF/ON)</div>
-      </div>
-      <!-- /.publish_schedule_controls -->
-    </div>
-    <!-- /.col-md-6 -->
-    <div class="col-md-6">
+    <div class="col-md-12">
       <div class="card card-body bg-light publish_schedule_controls">
         <span class="print_schedule">
           <%= link_to '<i class="fa fa-print fa-fw"></i> Print this Schedule'.html_safe, '#print', id: 'print-button', class: 'btn btn-secondary' %>
@@ -70,7 +59,7 @@
       </div>
       <!-- /.publish_schedule_controls -->
     </div>
-    <!-- /.col-md-6 -->
+    <!-- /.col-md-12 -->
   </div>
   <!-- /.row -->
   <% end %>

--- a/spec/controllers/schedule_controller_spec.rb
+++ b/spec/controllers/schedule_controller_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe ScheduleController, type: :controller do
         @event.schedules.delete_all
       end
 
-      it 'if event.publish_schedule is false, redirects to sign-in page' do
+      it 'redirects to sign-in page when publish_schedule is false' do
         @event.publish_schedule = false
         @event.save
 
@@ -59,29 +59,24 @@ RSpec.describe ScheduleController, type: :controller do
         expect(subject).to redirect_to(sign_in_path)
       end
 
-      it 'if event.publish_schedule is true, it assigns @schedules' do
+      it 'redirects to sign-in page even when publish_schedule is true' do
         expect(@event.schedules).not_to be_empty
         @event.publish_schedule = true
         @event.save
 
         get :index, params: { event_id: @event.id }
 
-        expect(@event.schedules).not_to be_empty
-        expect(response.status).to eq(200)
-        expect(response).to render_template('index')
-        expect(assigns(:schedules)).not_to be_empty
-      end
-
-      it 'if event.publish_schedule is true, but @schedules is empty,
-          it redirects to sign-in' do
-        @event.publish_schedule = true
-        @event.schedules.delete_all
-        @event.save
-
-        get :index, params: { format: :html, event_id: @event.id }
-
         expect(response.status).to eq(302)
         expect(subject).to redirect_to(sign_in_path)
+      end
+
+      it 'returns 401 for JSON requests when publish_schedule is true' do
+        @event.publish_schedule = true
+        @event.save
+
+        get :index, params: { event_id: @event.id, format: :json }
+
+        expect(response.status).to eq(401)
       end
     end
 


### PR DESCRIPTION
## Summary

Stops scammers from scraping participant names off public workshop schedules. Upcoming-workshop participants were contacted by a third party requesting accommodation payments after their names were harvested from schedule pages like `/events/2026/5-day-workshops/26w5574/schedule`.

## Root cause

`ScheduleController#index` skipped authentication and `DefaultSchedule#published_schedule` returned true whenever `event.publish_schedule` was on, so both the HTML page and the `.json` endpoint were unauthenticated and scrapeable (lecture titles + speaker names + affiliations come through via the schedule → lecture association).

## Changes

- `ScheduleController#index` now requires authentication (removed `except: [:index]`)
- `DefaultSchedule` uses a new `DefaultSchedulePolicy#can_view?` that allows organizers, admins, location staff, **and event members** — so legitimate participants still see their own schedule
- `DefaultSchedulePolicy#allow?` (used to trigger template copies) is unchanged — only organizers/staff/admins can still populate defaults
- `event.publish_schedule` no longer grants anonymous access; the flag column is left in place in case we want a future admin kill-switch or members-only relaxation
- Removed the now-inert "Publish Schedule" toggle UI from the schedule view
- Updated the external-user controller specs to assert redirect / 401 regardless of `publish_schedule`

## Test plan

- [ ] `bundle exec rspec spec/controllers/schedule_controller_spec.rb`
- [ ] `bundle exec rspec spec/services/default_schedule_spec.rb`
- [ ] Manually confirm on staging:
  - [ ] Anonymous GET `/events/:code/schedule` → redirect to sign-in
  - [ ] Anonymous GET `/events/:code/schedule.json` → 401
  - [ ] Logged-in participant of an event → sees their event's schedule
  - [ ] Logged-in non-participant → sees empty schedule (no leak)
  - [ ] Organizer → sees schedule + can still add/edit items
  - [ ] Print button still works on schedule page
- [ ] After merge + deploy: verify `https://www.birs.ca/events/.../schedule` pages no longer render participant names (depends on whether the www site proxies the JSON endpoint)

## Notes for reviewers

- The `publish_schedule` column on `events` is deliberately left in place. If we later want to re-expose schedules under tighter conditions (e.g., "public only after the workshop ends" or "admin kill-switch per event"), the column is reusable.
- `app/controllers/schedule_controller.rb` still has `publish_schedule` POST action and route — left intact but now effectively no-ops from a visibility standpoint.
