### PR TITLE
Fix SQL string interpolation in User event predicates

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -37,18 +37,23 @@ class User < ApplicationRecord
   end
 
   def is_organizer?(event)
-    person.memberships.where("event_id=#{event.id} AND role LIKE '%Org%'")
-          .count > 0
+    person.memberships
+          .where(event_id: event.id)
+          .where("role LIKE ?", "%Org%")
+          .exists?
   end
 
   def is_member?(event)
-    person.memberships.where("event_id=#{event.id} AND attendance != 'Declined'
-      AND attendance != 'Not Yet Invited'").count > 0
+    person.memberships
+          .where(event_id: event.id)
+          .where.not(attendance: ["Declined", "Not Yet Invited"])
+          .exists?
   end
 
   def is_confirmed_member?(event)
-    person.memberships.where("event_id=#{event.id}
-      AND attendance = 'Confirmed'").count > 0
+    person.memberships
+          .where(event_id: event.id, attendance: "Confirmed")
+          .exists?
   end
 
   def name

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -73,4 +73,113 @@ RSpec.describe User, type: :model do
     expect(u.role).not_to eq('staff')
     expect(u).to be_valid
   end
+
+  describe 'role predicates' do
+    it '#is_admin? true for admin' do
+      expect(build(:user, :admin).is_admin?).to be true
+    end
+
+    it '#is_admin? true for super_admin' do
+      expect(build(:user, :super_admin).is_admin?).to be true
+    end
+
+    it '#is_admin? false for staff' do
+      expect(build(:user, :staff).is_admin?).to be false
+    end
+
+    it '#is_admin? false for member' do
+      expect(build(:user).is_admin?).to be false
+    end
+
+    it '#is_staff? true for staff, admin, and super_admin' do
+      expect(build(:user, :staff).is_staff?).to be true
+      expect(build(:user, :admin).is_staff?).to be true
+      expect(build(:user, :super_admin).is_staff?).to be true
+    end
+
+    it '#is_staff? false for member' do
+      expect(build(:user).is_staff?).to be false
+    end
+  end
+
+  describe 'event membership predicates' do
+    let(:event) { create(:event, current: true) }
+    let(:other_event) { create(:event, current: true) }
+    let(:person) { create(:person) }
+    let(:user) { create(:user, person: person) }
+
+    describe '#is_organizer?' do
+      it 'true when person has Organizer role' do
+        create(:membership, person: person, event: event, role: 'Organizer')
+        expect(user.is_organizer?(event)).to be true
+      end
+
+      it 'true when person has Contact Organizer role' do
+        create(:membership, person: person, event: event, role: 'Contact Organizer')
+        expect(user.is_organizer?(event)).to be true
+      end
+
+      it 'false when person has Participant role' do
+        create(:membership, person: person, event: event, role: 'Participant')
+        expect(user.is_organizer?(event)).to be false
+      end
+
+      it 'false when person is organizer on a different event' do
+        create(:membership, person: person, event: other_event, role: 'Organizer')
+        expect(user.is_organizer?(event)).to be false
+      end
+
+      it 'false when no membership exists' do
+        expect(user.is_organizer?(event)).to be false
+      end
+    end
+
+    describe '#is_member?' do
+      %w[Confirmed Invited Undecided].each do |status|
+        it "true when attendance is #{status}" do
+          create(:membership, person: person, event: event, attendance: status)
+          expect(user.is_member?(event)).to be true
+        end
+      end
+
+      ['Declined', 'Not Yet Invited'].each do |status|
+        it "false when attendance is #{status}" do
+          create(:membership, person: person, event: event, attendance: status)
+          expect(user.is_member?(event)).to be false
+        end
+      end
+
+      it 'false when membership is for another event' do
+        create(:membership, person: person, event: other_event, attendance: 'Confirmed')
+        expect(user.is_member?(event)).to be false
+      end
+
+      it 'false when no membership exists' do
+        expect(user.is_member?(event)).to be false
+      end
+    end
+
+    describe '#is_confirmed_member?' do
+      it 'true when attendance is Confirmed' do
+        create(:membership, person: person, event: event, attendance: 'Confirmed')
+        expect(user.is_confirmed_member?(event)).to be true
+      end
+
+      %w[Invited Undecided Declined].each do |status|
+        it "false when attendance is #{status}" do
+          create(:membership, person: person, event: event, attendance: status)
+          expect(user.is_confirmed_member?(event)).to be false
+        end
+      end
+
+      it 'false when confirmed on a different event' do
+        create(:membership, person: person, event: other_event, attendance: 'Confirmed')
+        expect(user.is_confirmed_member?(event)).to be false
+      end
+
+      it 'false when no membership exists' do
+        expect(user.is_confirmed_member?(event)).to be false
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Rewrites the three event-membership predicates in \`app/models/user.rb\` that were building SQL \`where\` clauses via string interpolation. Stacks on #72.

\`\`\`ruby
# before
person.memberships.where(\"event_id=#{event.id} AND role LIKE '%Org%'\").count > 0

# after
person.memberships
      .where(event_id: event.id)
      .where(\"role LIKE ?\", \"%Org%\")
      .exists?
\`\`\`

### Why
- String interpolation of any value into a \`where(\"...\")\` is the canonical SQLi anti-pattern (CWE-89). Today \`event.id\` is always an integer so there's no live exploit, but the next refactor that passes a param-derived value turns it into a real vulnerability silently.
- Brakeman flagged the related \`event_decorators.rb\` site on similar grounds; these \`user.rb\` sites were missed by brakeman because it tracks integer model attributes, but the pattern is equally fragile.
- \`.count > 0\` → \`.exists?\` short-circuits and avoids loading a full count aggregate.

### Test coverage added
Extended \`spec/models/user_spec.rb\` (the existing model spec — my pre-start report was wrong that it was missing):
- \`#is_organizer?\` — Organizer / Contact Organizer / Participant / cross-event / no-membership
- \`#is_member?\` — Confirmed / Invited / Undecided (true); Declined / Not Yet Invited (false); cross-event; no-membership
- \`#is_confirmed_member?\` — Confirmed (true); Invited / Undecided / Declined (false); cross-event; no-membership
- Also added role-predicate coverage (\`#is_admin?\`, \`#is_staff?\`)

## Test plan

- [ ] Existing \`spec/models/user_spec.rb\` tests still pass
- [ ] New predicate tests pass
- [ ] No new rubocop offenses (verified locally)
- [ ] No new brakeman findings (verified locally)
- [ ] Manually exercise an event page with an organizer user and a declined user to confirm visible behavior unchanged

## Stack

Builds on #72 (security scanners CI). Rebase onto master once that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)