### PR TITLE
Fix Psych::DisallowedClass on YAML columns under Rails 5.2.8.1

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -17,5 +17,15 @@ module Workshops
     # the framework and any gems in your application.
 
     config.time_zone = "Mountain Time (US & Canada)"
+
+    # Rails 5.2.8.1 switched ActiveRecord YAML columns to Psych safe_load, which rejects
+    # classes not on this allowlist. Membership#invite_reminders is a Hash keyed by DateTime
+    # (and Person#grants), so without these we get Psych::DisallowedClass on load (500s the
+    # memberships page + crashes the reminder/stats/sync jobs). Allowlist keeps the hardening.
+    config.active_record.yaml_column_permitted_classes = [
+      Symbol, Date, Time, DateTime, BigDecimal,
+      ActiveSupport::TimeWithZone, ActiveSupport::TimeZone,
+      ActiveSupport::HashWithIndifferentAccess
+    ]
   end
 end


### PR DESCRIPTION
## Why
Rails 5.2.8.1's security release switched ActiveRecord YAML columns to `Psych.safe_load` with an empty permitted-classes allowlist. `Membership#invite_reminders` (a Hash keyed by `DateTime`) and `Person#grants` then raise `Psych::DisallowedClass` on read — 500ing the memberships page and crashing the stats/sync jobs. This is what rolled back the 2026-06-01 prod deploy.

## Fix
Set `config.active_record.yaml_column_permitted_classes` in `config/application.rb` to the classes our serialized data actually uses (Symbol, Date, Time, DateTime, BigDecimal, TimeWithZone, TimeZone, HashWithIndifferentAccess). Keeps the hardening, allows our data.

## Testing
Reproduced on wstaging against prod-shaped data: **11,322 memberships** threw `Psych::DisallowedClass: DateTime` before the fix; after the config loads, all sampled memberships read clean. Verified in the running app (not just a runtime tweak).

🤖 Generated with [Claude Code](https://claude.com/claude-code)