### PR TITLE
Suppress automated organizer emails while 2026/2027 workshops are held

### DIFF
--- a/app/jobs/que/double_check_attendance_job.rb
+++ b/app/jobs/que/double_check_attendance_job.rb
@@ -31,6 +31,7 @@ module Que
 
     def alert_staff
       return if email_group.count.zero?
+      return unless ::AutomatedEmailPolicy.enabled? # suppressed during the 2026/2027 hold
 
       AttendanceConfirmationMailer.alert_staff(event_id: event.id).deliver_now
     end
@@ -50,6 +51,8 @@ module Que
     end
 
     def send_emails
+      return unless ::AutomatedEmailPolicy.enabled? # suppressed during the 2026/2027 hold
+
       email_group.each do |invitation|
         AttendanceConfirmationMailer.remind(invitation_id: invitation.id).deliver_now
       end

--- a/app/jobs/que/report_event_statistics_job.rb
+++ b/app/jobs/que/report_event_statistics_job.rb
@@ -5,7 +5,9 @@ module Que
     def run(event_id:)
       event = Event.find(event_id)
 
-      EventStatisticsMailer.notify(event_id: event_id).deliver_now
+      # Suppressed while BIRS holds 2026/2027 workshops (see AutomatedEmailPolicy).
+      # Still reschedule so the recurrence survives a resume when the hold lifts.
+      EventStatisticsMailer.notify(event_id: event_id).deliver_now if ::AutomatedEmailPolicy.enabled?
 
       schedule_job(event)
     end

--- a/app/services/automated_email_policy.rb
+++ b/app/services/automated_email_policy.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Kill-switch for automated organizer/participant emails:
+#   * event-statistics notices  (Que::ReportEventStatisticsJob -> EventStatisticsMailer)
+#   * RSVP reminders / staff alerts (Que::DoubleCheckAttendanceJob -> AttendanceConfirmationMailer)
+#
+# BIRS is holding all 2026/2027 workshops (invites disabled), so these must NOT go
+# out in production — they tell organizers to "issue new invites" they cannot send,
+# which generates "why can't we invite?" questions to staff.
+#
+# Default: DISABLED (suppressed). Turn it on explicitly, per environment, with:
+#   ENABLE_AUTOMATED_EVENT_EMAILS=true
+# Set it in staging to exercise the mail path against MailHog; leave it unset/false
+# in production until the hosting hold lifts and invites are re-enabled. Test env
+# defaults enabled so existing mailer/job specs keep asserting the send path.
+module AutomatedEmailPolicy
+  ENV_FLAG = 'ENABLE_AUTOMATED_EVENT_EMAILS'
+
+  def self.enabled?
+    default = Rails.env.test? ? 'true' : 'false'
+    ENV.fetch(ENV_FLAG, default).to_s.strip.downcase == 'true'
+  end
+end

--- a/lib/tasks/que_ops.rake
+++ b/lib/tasks/que_ops.rake
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+# que_ops.rake — read-only visibility into the que backlog for deploys.
+#
+# Email-burst safety is handled in code by AutomatedEmailPolicy (the
+# ENABLE_AUTOMATED_EVENT_EMAILS kill-switch): while it is off, the mail-sending
+# jobs run but send nothing, so a worker restart can drain the backlog harmlessly.
+# This task just lets a deploy SEE what is queued.
+
+namespace :que do
+  MAIL_JOB_CLASSES = %w[
+    Que::ReportEventStatisticsJob
+    Que::DoubleCheckAttendanceJob
+  ].freeze
+
+  desc 'Report ready (due) vs future que jobs per class (read-only)'
+  task backlog: :environment do
+    conn = ActiveRecord::Base.connection
+    unless conn.table_exists?('que_jobs')
+      puts 'que:backlog — que_jobs table not present (nothing to report).'
+      next
+    end
+
+    rows = conn.select_all(<<~SQL).to_a
+      SELECT job_class,
+             count(*) FILTER (WHERE finished_at IS NULL AND expired_at IS NULL AND run_at <= now()) AS ready,
+             count(*) FILTER (WHERE finished_at IS NULL AND expired_at IS NULL AND run_at  > now()) AS future,
+             count(*) AS total
+      FROM que_jobs
+      GROUP BY job_class
+      ORDER BY ready DESC, job_class
+    SQL
+
+    puts format('%-46s %7s %8s %7s', 'job_class', 'READY', 'future', 'total')
+    puts '-' * 71
+    rows.each do |r|
+      flag = MAIL_JOB_CLASSES.include?(r['job_class']) ? ' *mail' : ''
+      puts format('%-46s %7s %8s %7s%s', r['job_class'], r['ready'], r['future'], r['total'], flag)
+    end
+    mail_ready = rows.select { |r| MAIL_JOB_CLASSES.include?(r['job_class']) }
+                     .sum { |r| r['ready'].to_i }
+    puts '-' * 71
+    puts "Mail-sending jobs READY now: #{mail_ready}"
+    enabled = defined?(AutomatedEmailPolicy) && AutomatedEmailPolicy.enabled?
+    puts "AutomatedEmailPolicy.enabled? = #{enabled} " \
+         "(#{enabled ? 'WILL SEND when run' : 'suppressed — safe to drain'})"
+  end
+end

--- a/spec/jobs/que/double_check_attendance_job_spec.rb
+++ b/spec/jobs/que/double_check_attendance_job_spec.rb
@@ -45,6 +45,18 @@ RSpec.describe Que::DoubleCheckAttendanceJob, type: :job do
     create(:invitation, membership: create_membership('Participant', attendance: 'Undecided'))
   end
 
+  describe 'when automated event emails are suppressed (2026/2027 hold)' do
+    before { allow(AutomatedEmailPolicy).to receive(:enabled?).and_return(false) }
+
+    subject { described_class.run(event_id: event.id, step: :rsvp_one_month_before_event) }
+
+    let(:start_date) { Date.today + 3.weeks } # would otherwise send 3 reminders
+
+    it 'does not send RSVP reminders' do
+      expect { subject }.not_to change { ActionMailer::Base.deliveries.count }
+    end
+  end
+
   describe '.enqueue' do
     context 'when event is Online' do
       let(:format) { 'Online' }

--- a/spec/jobs/que/report_event_statistics_job_spec.rb
+++ b/spec/jobs/que/report_event_statistics_job_spec.rb
@@ -57,6 +57,22 @@ RSpec.describe Que::ReportEventStatisticsJob, type: :job do
     end
   end
 
+  describe 'when automated event emails are suppressed (2026/2027 hold)' do
+    before { allow(AutomatedEmailPolicy).to receive(:enabled?).and_return(false) }
+
+    let(:event) { create(:event_with_members, start_date: 3.month.from_now, end_date: 3.month.from_now + 5.days) }
+
+    it 'does not send the statistics email' do
+      allow(EventStatisticsMailer).to receive(:notify).and_call_original
+      subject
+      expect(EventStatisticsMailer).not_to have_received(:notify)
+    end
+
+    it 'still reschedules the job so recurrence survives a resume' do
+      expect { subject }.to change { QueJobs.count }.by(1)
+    end
+  end
+
   describe 'participants count' do
     let(:event) { create(:event, event_format: 'Hybrid', max_participants: max_participants, max_virtual: 10) }
 

--- a/spec/services/automated_email_policy_spec.rb
+++ b/spec/services/automated_email_policy_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AutomatedEmailPolicy do
+  describe '.enabled?' do
+    after { ENV.delete(described_class::ENV_FLAG) }
+
+    it 'is true when ENABLE_AUTOMATED_EVENT_EMAILS=true' do
+      ENV[described_class::ENV_FLAG] = 'true'
+      expect(described_class.enabled?).to be true
+    end
+
+    it 'is false when explicitly set to false' do
+      ENV[described_class::ENV_FLAG] = 'false'
+      expect(described_class.enabled?).to be false
+    end
+
+    # The whole point: with no flag set, production must NOT send automated emails
+    # (BIRS is holding all 2026/2027 workshops).
+    it 'defaults to suppressed in production when the flag is unset' do
+      ENV.delete(described_class::ENV_FLAG)
+      allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new('production'))
+      expect(described_class.enabled?).to be false
+    end
+  end
+end


### PR DESCRIPTION
## Why
BIRS is holding all 2026/2027 workshops (invites disabled). The recurring event-statistics notices and RSVP reminders tell organizers to "issue new invites" they cannot send, generating "why can't we invite?" questions to staff. These must not go out in production. (The 2026-06-01 incident drained ~80 of these on a que restart.)

## What
- `AutomatedEmailPolicy` (`app/services/automated_email_policy.rb`) — kill-switch read from ENV `ENABLE_AUTOMATED_EVENT_EMAILS`. **Default = suppressed**; test env defaults enabled so existing specs keep asserting the send path.
- Guards in the two recurring mail jobs: `ReportEventStatisticsJob` skips the notice but **still reschedules** (recurrence survives a resume); `DoubleCheckAttendanceJob` skips the RSVP reminder + staff alert, keeping the internal sysadmin error path.
- `que:backlog` rake task reports queue + flag state.
- No migration — fits the no-migrations prod deploy.

## Testing (wstaging, green)
- Running-app round-trip: flag unset → `enabled?=false`, 0 deliveries; `ENABLE_AUTOMATED_EVENT_EMAILS=true` → sends to the real organizer.
- rspec: **20 examples, 0 failures** (policy unit spec + suppression contexts in both job specs + all existing job examples intact).

## Note / follow-up
Supersedes the older `fix/disable-scheduled-email-jobs` branch (DB-settings + a migration) for this deploy. That branch also carries a real fix worth folding in **when the hold lifts**: the `invitation.rb` `no_rsvp_from_confirmed` scope targets `Confirmed` (already-responded) instead of `Invited`, so re-enabled reminders would hit the wrong people. Moot while suppressed; track as a follow-up before flipping the flag back on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)